### PR TITLE
Kazuki test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Read keyboard input using **rusb** crate!   
+## Tips
+* Real time dmesg: ```sudo dmesg -e -w```
+* Show verbose lsusb: ```sudo lsusb -d ****:**** -v | less```
+* Re-connect usb device: ```sudo sh -c "echo -n *-* > /sys/bus/usb/drivers/usb/unbind && echo -n *-* > /sys/bus/usb/drivers/usb/bind"```

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -29,7 +29,7 @@ pub fn read_ascii_array<T: UsbContext>(
 
     let mut result = Ok(0);
 
-    let mut result2 = Ok(0);
+    let mut result_mouse = Ok(0);
 
     for endpoint in endpoints {
         // endpoint_address is expected to be 82
@@ -52,7 +52,7 @@ pub fn read_ascii_array<T: UsbContext>(
 
         result = match configure_endpoint(handle, &endpoint) {
             Ok(_) => {
-                    let timeout = Duration::from_secs(5);
+                    let timeout = Duration::from_secs(1);
                     match handle.read_interrupt(endpoint.address, buf, timeout) {
                         Ok(n_byte) => Ok(n_byte),
                         Err(e) => Err(format!("read_interrupt failed: {:?}", e)),
@@ -62,7 +62,7 @@ pub fn read_ascii_array<T: UsbContext>(
         };
 
         if endpoint.protocol_code == 2 {
-            result2 = result.clone();
+            result_mouse = result.clone();
         }
 
         if has_kernel_driver {
@@ -72,7 +72,7 @@ pub fn read_ascii_array<T: UsbContext>(
 
     
 
-    result2
+    result_mouse
 }
 
 // この関数は正しく実装されていることが保証されている

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,3 +1,5 @@
+// このコードの大部分はrusb公式githubのexamplesを参考にしている
+
 use rusb::{
     Device, DeviceDescriptor, DeviceHandle, Direction, GlobalContext, TransferType, UsbContext,
 };
@@ -27,6 +29,7 @@ pub fn read_ascii_array<T: UsbContext>(
     // endpoint_address is expected to be 82
     println!("endpoint address: 0x{:4x}", endpoint.address);
 
+    // とOS側のデータ転送要求と競合して？I/Oエラーが出る　https://github.com/libusb/libusb/wiki/FAQ#user-content-Does_libusb_support_USB_HID_devices
     let has_kernel_driver = match handle.kernel_driver_active(endpoint.iface) {
         Ok(true) => {
             handle.detach_kernel_driver(endpoint.iface).ok();
@@ -36,11 +39,17 @@ pub fn read_ascii_array<T: UsbContext>(
     };
     println!("has kernel driver? {}", has_kernel_driver);
 
-    let timeout = Duration::from_secs(5);
-    let result = match handle.read_interrupt(endpoint.address, buf, timeout) {
-        Ok(n_byte) => Ok(n_byte),
-        Err(e) => Err(format!("read_interrupt failed: {:?}", e)),
+    let result = match configure_endpoint(handle, &endpoint) {
+        Ok(_) => {
+                let timeout = Duration::from_secs(5);
+                match handle.read_interrupt(endpoint.address, buf, timeout) {
+                    Ok(n_byte) => Ok(n_byte),
+                    Err(e) => Err(format!("read_interrupt failed: {:?}", e)),
+                }
+        }
+        Err(err) => Err(format!("could not configure endpoint: {}", err)),
     };
+
 
     if has_kernel_driver {
         handle.attach_kernel_driver(endpoint.iface).ok();
@@ -80,4 +89,16 @@ fn find_readable_endpoint<T: UsbContext>(
         }
     }
     None
+}
+
+// attach_kernel_driverをするときに以下を実行しないと正しくドライバが適用されない
+// OSに接続されたUSBデバイスを一旦リセットし，libusbに接続されたデバイスとして初期化，再宣言，再設定する．
+fn configure_endpoint<T: UsbContext>(
+    handle: &mut DeviceHandle<T>,
+    endpoint: &Endpoint,
+) -> rusb::Result<()> {
+    handle.set_active_configuration(endpoint.config)?; // "issue a SET_CONFIGURATION request using the current configuration, causing most USB-related device state to be reset (altsetting reset to zero, endpoint halts cleared, toggles reset)."
+    handle.claim_interface(endpoint.iface)?; // "You must claim the interface you wish to use before you can perform I/O on any of its endpoints. instruct the underlying operating system that your application wishes to take ownership of the interface."
+    handle.set_alternate_setting(endpoint.iface, endpoint.setting)?; // Activate an alternate setting for an interface.
+    Ok(()) // could not configure endpoint: Resource busy
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -101,4 +101,5 @@ fn configure_endpoint<T: UsbContext>(
     handle.claim_interface(endpoint.iface)?; // "You must claim the interface you wish to use before you can perform I/O on any of its endpoints. instruct the underlying operating system that your application wishes to take ownership of the interface."
     handle.set_alternate_setting(endpoint.iface, endpoint.setting)?; // Activate an alternate setting for an interface.
     Ok(()) // could not configure endpoint: Resource busy
+    // dmesg: "usbfs: interface 0 claimed by usbhid while 'rust-keyboard-h' sets config #1"
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -3,33 +3,58 @@ use rusb::{
 };
 use std::time::Duration;
 
+#[derive(Debug)]
+struct Endpoint {
+    config: u8,
+    iface: u8,
+    setting: u8,
+    address: u8,
+}
+
 pub fn read_ascii_array<T: UsbContext>(
     device: &mut Device<T>,
     device_desc: DeviceDescriptor,
-    handle: DeviceHandle<GlobalContext>,
+    handle: &mut DeviceHandle<GlobalContext>,
     transfer_type: TransferType,
     buf: &mut [u8],
 ) -> Result<usize, String> {
-    let endpoint_address = match find_readable_endpoint_address(device, device_desc, transfer_type)
+    let endpoint = match find_readable_endpoint(device, device_desc, transfer_type)
     {
-        Some(address) => address,
+        Some(endpoint) => endpoint,
         None => return Err(String::from("endpoint not found")),
     };
 
-    // endpoint_address is expected to be 81
-    let timeout = Duration::from_secs(10);
-    match handle.read_interrupt(endpoint_address, buf, timeout) {
+    // endpoint_address is expected to be 82
+    println!("endpoint address: 0x{:4x}", endpoint.address);
+
+    let has_kernel_driver = match handle.kernel_driver_active(endpoint.iface) {
+        Ok(true) => {
+            handle.detach_kernel_driver(endpoint.iface).ok();
+            true
+        }
+        _ => false,
+    };
+    println!("has kernel driver? {}", has_kernel_driver);
+
+    let timeout = Duration::from_secs(5);
+    let result = match handle.read_interrupt(endpoint.address, buf, timeout) {
         Ok(n_byte) => Ok(n_byte),
         Err(e) => Err(format!("read_interrupt failed: {:?}", e)),
+    };
+
+    if has_kernel_driver {
+        handle.attach_kernel_driver(endpoint.iface).ok();
     }
+
+    result
 }
 
 // この関数は正しく実装されていることが保証されている
-fn find_readable_endpoint_address<T: UsbContext>(
+fn find_readable_endpoint<T: UsbContext>(
     device: &mut Device<T>,
     device_desc: DeviceDescriptor,
     transfer_type: TransferType,
-) -> Option<u8> {
+) -> Option<Endpoint> {
     for n in 0..device_desc.num_configurations() {
         let config_desc = match device.config_descriptor(n) {
             Ok(c) => c,
@@ -41,8 +66,14 @@ fn find_readable_endpoint_address<T: UsbContext>(
                 for endpoint_desc in interface_desc.endpoint_descriptors() {
                     if endpoint_desc.direction() == Direction::In
                         && endpoint_desc.transfer_type() == transfer_type
+                            && interface_desc.protocol_code() == 2 // Mouse
                     {
-                        return Some(endpoint_desc.address());
+                        return Some(Endpoint {
+                            config: config_desc.number(),
+                            iface: interface_desc.interface_number(),
+                            setting: interface_desc.setting_number(),
+                            address: endpoint_desc.address(),
+                        });
                     }
                 }
             }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -15,8 +15,9 @@ struct Endpoint {
 }
 
 enum InterfaceProcol {
-  Keyboard = 1,
-  Mouse = 2,
+    Device = 0,
+    Keyboard = 1,
+    Mouse = 2,
 }
 
 pub fn read_ascii_array<T: UsbContext>(
@@ -56,7 +57,7 @@ pub fn read_ascii_array<T: UsbContext>(
         
     }
     for endpoint in endpoints.to_vec() {
-        if endpoint.protocol_code != 0 {
+        if endpoint.protocol_code != InterfaceProcol::Device as u8 {
             continue;
         }
         result = match configure_endpoint(handle, &endpoint) {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -53,11 +53,12 @@ pub fn read_ascii_array<T: UsbContext>(
         result = match configure_endpoint(handle, &endpoint) {
             Ok(_) => {
                     let timeout = Duration::from_secs(1);
-                    match handle.read_interrupt(endpoint.address, buf, timeout) {
-                        Ok(n_byte) => Ok(n_byte),
-                        Err(e) => Err(format!("read_interrupt failed: {:?}", e)),
-                    }
-            }
+                    // match handle.read_interrupt(endpoint.address, buf, timeout) {
+                    //     Ok(n_byte) => Ok(n_byte),
+                    //     Err(e) => Err(format!("read_interrupt failed: {:?}", e)),
+                    // }
+                    Ok(0)
+            },
             Err(err) => Err(format!("could not configure endpoint{:x}: {}", endpoint.address, err)),
         };
 
@@ -65,7 +66,7 @@ pub fn read_ascii_array<T: UsbContext>(
             result_mouse = result.clone();
         }
 
-        if has_kernel_driver {
+        if has_kernel_driver == true {
             handle.attach_kernel_driver(endpoint.iface).ok();
         }
     }
@@ -118,11 +119,11 @@ fn configure_endpoint<T: UsbContext>(
     handle: &mut DeviceHandle<T>,
     endpoint: &Endpoint,
 ) -> rusb::Result<()> {
-    // handle.set_active_configuration(endpoint.config)?; // "issue a SET_CONFIGURATION request using the current configuration, causing most USB-related device state to be reset (altsetting reset to zero, endpoint halts cleared, toggles reset)."
+    handle.set_active_configuration(endpoint.config)?; // "issue a SET_CONFIGURATION request using the current configuration, causing most USB-related device state to be reset (altsetting reset to zero, endpoint halts cleared, toggles reset)."
     // source: https://github.com/libusb/libusb/blob/9e077421b8708d98c8d423423bd6678dca0ef2ae/libusb/core.c#L1733
-    // handle.claim_interface(endpoint.iface)?; // "You must claim the interface you wish to use before you can perform I/O on any of its endpoints. instruct the underlying operating system that your application wishes to take ownership of the interface."
+    handle.claim_interface(endpoint.iface)?; // "You must claim the interface you wish to use before you can perform I/O on any of its endpoints. instruct the underlying operating system that your application wishes to take ownership of the interface."
     // source: https://github.com/libusb/libusb/blob/9e077421b8708d98c8d423423bd6678dca0ef2ae/libusb/core.c#L1770
-    // handle.set_alternate_setting(endpoint.iface, endpoint.setting)?; // Activate an alternate setting for an interface.
+    handle.set_alternate_setting(endpoint.iface, endpoint.setting)?; // Activate an alternate setting for an interface.
     // source: https://github.com/libusb/libusb/blob/9e077421b8708d98c8d423423bd6678dca0ef2ae/libusb/core.c#L1859
     Ok(()) // could not configure endpoint: Resource busy
     // dmesg: "usbfs: interface 0 claimed by usbhid while 'rust-keyboard-h' sets config #1"

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -14,6 +14,11 @@ struct Endpoint {
     protocol_code: u8,
 }
 
+enum InterfaceProcol {
+  Keyboard = 1,
+  Mouse = 2,
+}
+
 pub fn read_ascii_array<T: UsbContext>(
     device: &mut Device<T>,
     device_desc: DeviceDescriptor,
@@ -36,7 +41,7 @@ pub fn read_ascii_array<T: UsbContext>(
         println!("endpoint address: 0x{:4x}", endpoint.address);
         println!("endpoint: {:?}", endpoint);
 
-        if endpoint.protocol_code != 0 {
+        if endpoint.protocol_code != InterfaceProcol::Keyboard as u8 {
             continue;
         }
 
@@ -50,7 +55,7 @@ pub fn read_ascii_array<T: UsbContext>(
         };
         std::thread::sleep(std::time::Duration::from_secs(1));
         println!("has kernel driver? {}", has_kernel_driver);
-        
+
 
         result = match configure_endpoint(handle, &endpoint) {
             Ok(_) => {
@@ -74,7 +79,7 @@ pub fn read_ascii_array<T: UsbContext>(
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
 
-    
+
     std::thread::sleep(std::time::Duration::from_secs(3));
     result_mouse
 }
@@ -123,11 +128,11 @@ fn configure_endpoint<T: UsbContext>(
     endpoint: &Endpoint,
 ) -> rusb::Result<()> {
     // ?演算子：　Errorを受け取ると"""即座に"""returnする => claim_interfaceとset_alternate_settingが呼ばれていなかった
-    // handle.set_active_configuration(endpoint.config)?; // "issue a SET_CONFIGURATION request using the current configuration, causing most USB-related device state to be reset (altsetting reset to zero, endpoint halts cleared, toggles reset)."
-    // // source: https://github.com/libusb/libusb/blob/9e077421b8708d98c8d423423bd6678dca0ef2ae/libusb/core.c#L1733
-    // // Resource Busy
+    handle.set_active_configuration(endpoint.config)?; // "issue a SET_CONFIGURATION request using the current configuration, causing most USB-related device state to be reset (altsetting reset to zero, endpoint halts cleared, toggles reset)."
+    // source: https://github.com/libusb/libusb/blob/9e077421b8708d98c8d423423bd6678dca0ef2ae/libusb/core.c#L1733
+    // Resource Busy
     // handle.claim_interface(endpoint.iface)?; // "You must claim the interface you wish to use before you can perform I/O on any of its endpoints. instruct the underlying operating system that your application wishes to take ownership of the interface."
-    // // source: https://github.com/libusb/libusb/blob/9e077421b8708d98c8d423423bd6678dca0ef2ae/libusb/core.c#L1770
+    // source: https://github.com/libusb/libusb/blob/9e077421b8708d98c8d423423bd6678dca0ef2ae/libusb/core.c#L1770
     // handle.set_alternate_setting(endpoint.iface, endpoint.setting)?; // Activate an alternate setting for an interface.
     // source: https://github.com/libusb/libusb/blob/9e077421b8708d98c8d423423bd6678dca0ef2ae/libusb/core.c#L1859
     // Entity not found

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -29,6 +29,8 @@ pub fn read_ascii_array<T: UsbContext>(
 
     let mut result = Ok(0);
 
+    let mut result2 = Ok(0);
+
     for endpoint in endpoints {
         // endpoint_address is expected to be 82
         println!("endpoint address: 0x{:4x}", endpoint.address);
@@ -56,9 +58,12 @@ pub fn read_ascii_array<T: UsbContext>(
                         Err(e) => Err(format!("read_interrupt failed: {:?}", e)),
                     }
             }
-            Err(err) => Err(format!("could not configure endpoint: {}", err)),
+            Err(err) => Err(format!("could not configure endpoint{:x}: {}", endpoint.address, err)),
         };
 
+        if endpoint.protocol_code == 2 {
+            result2 = result.clone();
+        }
 
         if has_kernel_driver {
             handle.attach_kernel_driver(endpoint.iface).ok();
@@ -67,7 +72,7 @@ pub fn read_ascii_array<T: UsbContext>(
 
     
 
-    result
+    result2
 }
 
 // この関数は正しく実装されていることが保証されている

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -118,11 +118,11 @@ fn configure_endpoint<T: UsbContext>(
     handle: &mut DeviceHandle<T>,
     endpoint: &Endpoint,
 ) -> rusb::Result<()> {
-    handle.set_active_configuration(endpoint.config)?; // "issue a SET_CONFIGURATION request using the current configuration, causing most USB-related device state to be reset (altsetting reset to zero, endpoint halts cleared, toggles reset)."
+    // handle.set_active_configuration(endpoint.config)?; // "issue a SET_CONFIGURATION request using the current configuration, causing most USB-related device state to be reset (altsetting reset to zero, endpoint halts cleared, toggles reset)."
     // source: https://github.com/libusb/libusb/blob/9e077421b8708d98c8d423423bd6678dca0ef2ae/libusb/core.c#L1733
-    handle.claim_interface(endpoint.iface)?; // "You must claim the interface you wish to use before you can perform I/O on any of its endpoints. instruct the underlying operating system that your application wishes to take ownership of the interface."
+    // handle.claim_interface(endpoint.iface)?; // "You must claim the interface you wish to use before you can perform I/O on any of its endpoints. instruct the underlying operating system that your application wishes to take ownership of the interface."
     // source: https://github.com/libusb/libusb/blob/9e077421b8708d98c8d423423bd6678dca0ef2ae/libusb/core.c#L1770
-    handle.set_alternate_setting(endpoint.iface, endpoint.setting)?; // Activate an alternate setting for an interface.
+    // handle.set_alternate_setting(endpoint.iface, endpoint.setting)?; // Activate an alternate setting for an interface.
     // source: https://github.com/libusb/libusb/blob/9e077421b8708d98c8d423423bd6678dca0ef2ae/libusb/core.c#L1859
     Ok(()) // could not configure endpoint: Resource busy
     // dmesg: "usbfs: interface 0 claimed by usbhid while 'rust-keyboard-h' sets config #1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,10 @@ fn main() {
             rusb::TransferType::Interrupt,
             &mut buf,
         ) {
-            Ok(n) => println!("n is {}", n),
+            Ok(n) => {
+                println!("n is {}", n);
+                println!("Received data: {:?}", &buf[0..n]);
+            },
             Err(e) => panic!("{}", e),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ mod frame;
 use rusb;
 
 fn main() {
-    let target_vid: u16 = 0x0c45;
-    let target_pid: u16 = 0x7680;
+    let target_vid: u16 = 0x046d;
+    let target_pid: u16 = 0xc53f;
     let mut buf: [u8; 256] = [0; 256];
     for mut device in rusb::devices().unwrap().iter() {
         let device_descriptor = device.device_descriptor().unwrap();
@@ -22,7 +22,7 @@ fn main() {
             continue;
         }
 
-        let handle = match device.open() {
+        let mut handle = match device.open() {
             Ok(handle) => handle,
             Err(e) => panic!("{}", e),
         };
@@ -30,7 +30,7 @@ fn main() {
         match frame::read_ascii_array(
             &mut device,
             device_descriptor,
-            handle,
+            &mut handle,
             rusb::TransferType::Interrupt,
             &mut buf,
         ) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use std::thread::sleep_ms;
 use rusb;
 
 fn main() {
-    let target_vid: u16 = 0x413c;
-    let target_pid: u16 = 0x2003;
+    let target_vid: u16 = 0x046d;
+    let target_pid: u16 = 0xc53f;
     let mut buf: [u8; 256] = [0; 256];
     for mut device in rusb::devices().unwrap().iter() {
         let device_descriptor = device.device_descriptor().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 mod frame;
+use std::thread::sleep_ms;
+
 use rusb;
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use std::thread::sleep_ms;
 use rusb;
 
 fn main() {
-    let target_vid: u16 = 0x046d;
-    let target_pid: u16 = 0xc53f;
+    let target_vid: u16 = 0x413c;
+    let target_pid: u16 = 0x2003;
     let mut buf: [u8; 256] = [0; 256];
     for mut device in rusb::devices().unwrap().iter() {
         let device_descriptor = device.device_descriptor().unwrap();


### PR DESCRIPTION
Added following codes:
1. get all endpoints
2. detach all interfaces
3. set a configuration
4. claim an interface for mouse
5. activate an alternate setting for mouse interface
6. read_interrupt from mouse
7. release mouse interface
8. let OS attach driver to interfaces

All working successfully.